### PR TITLE
Add support for `only` option sent to happo.init

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,13 @@ let currentIndex = 0;
 const happoStatic = {
   init() {
     window.happo = window.happo || {};
-    window.happo.init = ({ targetName, chunk }) => {
+    window.happo.init = ({ targetName, chunk, only }) => {
       currentIndex = 0;
-      if (chunk) {
+      if (only) {
+        examples = examples.filter(
+          e => e.component === only.component && e.variant === only.variant,
+        );
+      } else if (chunk) {
         const examplesPerChunk = Math.ceil(examples.length / chunk.total);
         const startIndex = chunk.index * examplesPerChunk;
         const endIndex = startIndex + examplesPerChunk;
@@ -68,6 +72,11 @@ const happoStatic = {
     }
     examples.push(props);
   },
+
+  reset() {
+    examples = [];
+    currentIndex = 0;
+  }
 };
 
 module.exports = happoStatic;

--- a/index.test.js
+++ b/index.test.js
@@ -4,12 +4,80 @@ beforeEach(() => {
   global.window = {};
 });
 
+afterEach(() => {
+  happoStatic.reset();
+});
+
 it('#init sets up some globals', () => {
   expect(global.window.happo).toBeFalsy();
   happoStatic.init();
   expect(global.window.happo).toBeTruthy();
   expect(typeof global.window.happo.nextExample).toEqual('function');
   expect(typeof global.window.happo.init).toEqual('function');
+});
+
+describe('when happo.init is called with only option', () => {
+  it('filters examples to only the single one', async () => {
+    happoStatic.init();
+    happoStatic.registerExample({
+      component: 'Hello',
+      variant: 'red',
+      render: () => {
+        return '<div style="background-color:red">Hello</div>';
+      },
+    });
+
+    happoStatic.registerExample({
+      component: 'Hello',
+      variant: 'blue',
+      render: () => {
+        return '<div style="background-color:blue">Hello</div>';
+      },
+    });
+
+    global.window.happo.init({ only: { component: 'Hello', variant: 'blue' } });
+    expect(await global.window.happo.nextExample()).toEqual({
+      component: 'Hello',
+      variant: 'blue',
+    });
+    expect(await global.window.happo.nextExample()).toBeFalsy();
+  });
+});
+
+describe('when happo.init is called with chunk option', () => {
+  it('filters examples to the right ones', async () => {
+    happoStatic.init();
+    happoStatic.registerExample({
+      component: 'Hello',
+      variant: 'red',
+      render: () => {
+        return '<div style="background-color:red">Hello</div>';
+      },
+    });
+
+    happoStatic.registerExample({
+      component: 'Hello',
+      variant: 'blue',
+      render: () => {
+        return '<div style="background-color:blue">Hello</div>';
+      },
+    });
+
+    happoStatic.registerExample({
+      component: 'Hello',
+      variant: 'green',
+      render: () => {
+        return '<div style="background-color:green">Hello</div>';
+      },
+    });
+
+    global.window.happo.init({ chunk: { total: 3, index: 2 } });
+    expect(await global.window.happo.nextExample()).toEqual({
+      component: 'Hello',
+      variant: 'green',
+    });
+    expect(await global.window.happo.nextExample()).toBeFalsy();
+  });
 });
 
 it('can iterate over registered examples', async () => {


### PR DESCRIPTION
An upcoming feature for Happo will allow people to retry a single example in a snap-request. This commit will ensure that this new option is honored.